### PR TITLE
feat: upgrade to material 0.35.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,120 @@
-# list
+# MaterialR List
+
+**@materialr/list**
+
+[![Build Status](https://travis-ci.org/materialr/list.svg?branch=master)](https://travis-ci.org/materialr/list)
+[![Coverage Status](https://coveralls.io/repos/github/materialr/list/badge.svg?branch=master)](https://coveralls.io/github/materialr/list?branch=master)
+[![NSP Status](https://nodesecurity.io/orgs/materialr/projects/781e1159-7da9-4317-87ca-bffa2b49d70b/badge)](https://nodesecurity.io/orgs/materialr/projects/781e1159-7da9-4317-87ca-bffa2b49d70b)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 React Material list implementation.
+
+## Installation
+
+```sh
+$ npm install --save @materialr/list
+```
+
+## Demo
+
+A full demo is available on the [MaterialR website](https://materialr.github.io/components/list)
+showcasing all variants.
+
+## Components
+
+### Named exports
+
+```js
+import { List } from '@materialr/list';
+```
+
+**Props**
+
+| Prop        | Type            | Required | Default   | Description                                          |
+| ----------- | --------------- | -------- | --------- | ---------------------------------------------------- |
+| `avatar`    | bool            | No       | false     | Whether the list contains avatar as opposed to icons |
+| `children`  | node            | Yes      | N/A       | The child elements to render inside the list         |
+| `className` | string          | No       | undefined | Additional classNames to add                         |
+| `dense`     | bool            | No       | false     | Whether a dense list is to be rendered               |
+| `display`   | enum (list/nav) | No       | list      | Whether to render a list (`<ul>`) or nav (`<nav>`)   |
+| `twoLines`  | bool            | No       | false     | Whether this is a list with two-line list items      |
+
+```js
+import { ListGroup } from '@materialr/list';
+```
+
+| Prop        | Type        | Required | Default   | Description                   |
+| ----------- | ----------- | -------- | --------- | ----------------------------- |
+| `children`  | node        | Yes      | undefined | The children to render within |
+| `className` | string      | No       | undefined | Additional classNames to add  |
+
+```js
+import { ListGroupSubheader } from '@materialr/list';
+```
+
+| Prop        | Type        | Required | Default   | Description                  |
+| ----------- | ----------- | -------- | --------- | ---------------------------- |
+| `className` | string      | No       | undefined | Additional classNames to add |
+| `title`     | string      | Yes      | undefined | The title to render within   |
+
+```js
+import { ListItem } from '@materialr/list';
+```
+
+| Prop              | Type        | Required | Default   | Description                                             |
+| ----------------- | ----------- | -------- | --------- | ------------------------------------------------------- |
+| `activated`       | bool        | No       | false     | Whether this item is activated                          |
+| `AnchorComponent` | func        | No       | undefined | A React component to render instead of an `<a>` element |
+| `anchorProps`     | shape       | No       | {}        | Additional props to pass to the anchor component        |
+| `className`       | string      | No       | undefined | Additional classNames to add                            |
+| `children`        | node        | Yes      | undefined | The children to render within                           |
+| `href`            | string      | No       | undefined | The url where the list item should navigate to          |
+
+```js
+import { listItemDivider } from '@materialr/list';
+```
+
+| Prop        | Type   | Required | Default   | Description                                |
+| ----------- | ------ | -------- | --------- | ------------------------------------------ |
+| `className` | string | No       | undefined | Additional classNames to add               |
+| `inset`     | bool   | No       | false     | Whether the divider is inset from the side |
+
+```js
+import { ListItemGraphic } from '@materialr/list';
+```
+
+| Prop        | Type        | Required         | Default   | Description                  |
+| ----------- | ----------- | ---------------- | --------- | ---------------------------- |
+| `avatar`    | string      | without `icon`   | undefined | An avatar image to render    |
+| `className` | string      | No               | undefined | Additional classNames to add |
+| `icon`      | string      | without `avatar` | undefined | A material icon to render    |
+| `title`     | string      | with `avatar`    | undefined | A title to add to an avatar  |
+
+```js
+import { listItemMeta } from '@materialr/list';
+```
+
+| Prop        | Type        | Required | Default   | Description                  |
+| ----------- | ----------- | -------- | --------- | ---------------------------- |
+| `className` | string      | No       | undefined | Additional classNames to add |
+| `icon`      | string      | Yes      | N/A       | A material icon to render    |
+| `onClick`   | func        | No       | undefined | A click handler method       |
+| `title`     | string      | Yes      | N/A       | The title attribute          |
+
+```js
+import { ListItemSecondaryText } from '@materialr/list';
+```
+
+| Prop        | Type   | Required | Default   | Description                  |
+| ----------- | ------ | -------- | --------- | ---------------------------- |
+| `className` | string | No       | undefined | Additional classNames to add |
+| `text`      | string | Yes      | N/A       | The text to add              |
+
+```js
+import { ListItemText } from '@materialr/list';
+```
+
+| Prop        | Type        | Required | Default   | Description                   |
+| ----------- | ----------- | -------- | --------- | ----------------------------- |
+| `children`  | node        | Yes      | undefined | The children to render within |
+| `className` | string      | No       | undefined | Additional classNames to add  |

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,47 +55,45 @@
         }
       }
     },
+    "@material/base": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-0.35.0.tgz",
+      "integrity": "sha512-PYuluVzcH8hxtionVvpTSygTENlgyOHvJ5ka7JfbCRQfXlxjV8zKYwhh9u/1HqA6y1OonG1oGFCaBHopbdsNEQ=="
+    },
     "@material/list": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@material/list/-/list-0.34.1.tgz",
-      "integrity": "sha512-CSOIUcWNg3ot0ULdvAR8NMU71+K+rXZyBr/TH0J47fxDYVrbz6TW19QGb6Cr3PyNyY/DSe5lwVsYRiA//6SEFg==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@material/list/-/list-0.35.0.tgz",
+      "integrity": "sha512-H8F2ej4nnnKXVV6JmR+i8/aA8wkp/i1uslU6RmNC7+E2aeyEiKdk2xOEuq9JdQjgm4zJyIA6jYSr2CQVVdhBuw==",
       "requires": {
-        "@material/ripple": "0.34.1",
-        "@material/rtl": "0.34.0",
-        "@material/theme": "0.34.0",
-        "@material/typography": "0.34.0"
-      },
-      "dependencies": {
-        "@material/base": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@material/base/-/base-0.34.0.tgz",
-          "integrity": "sha512-HFYy+AHPqPLv2V2aO+tlkhUH/wmt6PCfMzvGPS/ggef/nysu7akC95BG8iaQBCqjpq5sFXDWk7SEdJb/9NHJIQ=="
-        },
-        "@material/ripple": {
-          "version": "0.34.1",
-          "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-0.34.1.tgz",
-          "integrity": "sha512-lVCbGW/k6pSIyNiB1ur6L+fiU3yWgMFGHBwoEB+9DPj9VJsOgQW10uDfmnIjDZ/xYYVNjL+Y2MiW7DCMamhLdg==",
-          "requires": {
-            "@material/base": "0.34.0",
-            "@material/theme": "0.34.0"
-          }
-        },
-        "@material/rtl": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-0.34.0.tgz",
-          "integrity": "sha512-e4gxmJT1ll2w8jL0TXxFshdBgFbb+VMgyIC4N6DigcPuG07HpY5dZwaA92Gd1C+uQoLv4PEaqidt6ZMpVeDzKw=="
-        },
-        "@material/theme": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@material/theme/-/theme-0.34.0.tgz",
-          "integrity": "sha512-PXFRQ9Q8ycXz9ihb0UAGgnBTVzIq0Qd3jgonHLYMzIL9+8D4BrQqJlM9uyyN5N/7KwesP7ItiumdfZ5f5gfAxw=="
-        },
-        "@material/typography": {
-          "version": "0.34.0",
-          "resolved": "https://registry.npmjs.org/@material/typography/-/typography-0.34.0.tgz",
-          "integrity": "sha512-NMFBSdwvUzhRVQQxK6m1dMHB4R1eGKsbkIOiBvsiclUF7bailSXJh8p+ki4YolTOy/jvNTdGlUMqF0W+/ebdtw=="
-        }
+        "@material/ripple": "0.35.0",
+        "@material/rtl": "0.35.0",
+        "@material/theme": "0.35.0",
+        "@material/typography": "0.35.0"
       }
+    },
+    "@material/ripple": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-0.35.0.tgz",
+      "integrity": "sha512-zc/yjZ1DC1rNPaGrH6XkU/S2hgq8qy+ibq4cg0I3G8dWZyI0rXnh7RVFGsEk66z0hvEzD/du2xWPH5dyShFW/A==",
+      "requires": {
+        "@material/base": "0.35.0",
+        "@material/theme": "0.35.0"
+      }
+    },
+    "@material/rtl": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-0.35.0.tgz",
+      "integrity": "sha512-Cn5xpwgVuB37NUTAPS+TMZ+XLJaztp7oDrv5y73zu0ZjTnf9HPAsS16ovauf8HQqMaZyAj9B3tvZHL05g4y5pA=="
+    },
+    "@material/theme": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-0.35.0.tgz",
+      "integrity": "sha512-jTjRDPKlWVCNnSs4RRe/eq9+F5lFBzxfbuI7klgCR6jTXRMB93jKKKO7k6chgo9l0oObhLh81ao6sq/eV0WFIw=="
+    },
+    "@material/typography": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-0.35.0.tgz",
+      "integrity": "sha512-7uXybSQToQCgB19RT0Pq47NkXSSojpbccVAObw/7fmfNUTcr3elNc8iPS/f1slYDTDEdyqM7hCreLcfZQK8ATQ=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -687,7 +685,7 @@
       "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
+        "babel-core": "6.26.3",
         "babel-polyfill": "6.26.0",
         "babel-register": "6.26.0",
         "babel-runtime": "6.26.0",
@@ -716,9 +714,9 @@
       }
     },
     "babel-core": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+      "version": "6.26.3",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
@@ -1619,7 +1617,7 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
+        "babel-core": "6.26.3",
         "babel-runtime": "6.26.0",
         "core-js": "2.5.3",
         "home-or-tmp": "2.0.0",
@@ -6506,7 +6504,7 @@
       "integrity": "sha512-Eat/esQjevhx9BgJEC8udye+FfoJ2qvxAZfOAWshYGS22HydHn5BgsvPdTtt9cp0fSl5LxYOFA1Pja9Iz2Zt8g==",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
+        "babel-core": "6.26.3",
         "babel-jest": "22.4.3",
         "babel-plugin-istanbul": "4.1.5",
         "chalk": "2.3.2",
@@ -8382,9 +8380,9 @@
       }
     },
     "react": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.3.1.tgz",
-      "integrity": "sha512-NbkxN9jsZ6+G+ICsLdC7/wUD26uNbvKU/RAxEWgc9kcdKvROt+5d5j2cNQm5PSFTQ4WNGsR3pa4qL2Q0/WSy1w==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-o5GPdkhciQ3cEph6qgvYB7LTOHw/GB0qRI6ZFNugj49qJCFfgHwVNjZ5u+b7nif4vOeMIOuYj3CeYe2IBD74lg==",
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
@@ -8393,9 +8391,9 @@
       }
     },
     "react-dom": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.1.tgz",
-      "integrity": "sha512-2Infg89vzahq8nfVi1GkjPqq0vrBvf0f3T0+dTtyjq4f6HKOqKixAK25Vr593O3QTx4kw/vmUtAJwerlevNWOA==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.2.tgz",
+      "integrity": "sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==",
       "dev": true,
       "requires": {
         "fbjs": "0.8.16",

--- a/package.json
+++ b/package.json
@@ -28,14 +28,14 @@
   },
   "homepage": "https://github.com/materialr/list#readme",
   "dependencies": {
-    "@material/list": "^0.34.1",
+    "@material/list": "^0.35.0",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.1",
-    "react": "^16.3.1"
+    "react": "^16.3.2"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
-    "babel-core": "^6.26.0",
+    "babel-core": "^6.26.3",
     "babel-jest": "^22.4.3",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
@@ -50,7 +50,7 @@
     "eslint-plugin-react": "^7.7.0",
     "jest": "^22.4.3",
     "nsp": "^3.2.1",
-    "react-dom": "^16.3.1",
+    "react-dom": "^16.3.2",
     "semantic-release": "^15.1.7"
   }
 }

--- a/src/list-item.jsx
+++ b/src/list-item.jsx
@@ -2,25 +2,45 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export const getClassNames = (activated, className) => classnames({
-  'mdc-list-item': true,
-  'mdc-list-item--activated': activated,
-  [className]: !!className,
-});
-
-const isAnchorListItem = href => !!href;
-const isCustomAnchor = AnchorComponent => !!AnchorComponent;
-
-const ListItem = ({ activated, AnchorComponent, anchorProps, className, children, href }) => {
-  const classNames = getClassNames(activated, className);
-  if (isAnchorListItem(href)) {
-    return <a {...anchorProps} className={classNames} href={href}>{children}</a>;
+class ListItem extends React.Component {
+  constructor(props) {
+    super(props);
+    this.getClassNames = this.getClassNames.bind(this);
+    this.isAnchorListItem = this.isAnchorListItem.bind(this);
+    this.isCustomAnchor = this.isCustomAnchor.bind(this);
   }
-  if (isCustomAnchor(AnchorComponent)) {
-    return <AnchorComponent {...anchorProps} className={classNames}>{children}</AnchorComponent>;
+  getClassNames() {
+    const { activated, className } = this.props;
+    return classnames({
+      'mdc-list-item': true,
+      'mdc-list-item--activated': activated,
+      [className]: !!className,
+    });
   }
-  return <li className={classNames}>{children}</li>;
-};
+  isAnchorListItem() {
+    return !!this.props.href;
+  }
+  isCustomAnchor() {
+    return !!this.props.AnchorComponent;
+  }
+  render() {
+    const {
+      getClassNames,
+      isAnchorListItem,
+      isCustomAnchor,
+      props: { AnchorComponent, anchorProps, children, href },
+    } = this;
+    if (isAnchorListItem()) {
+      return <a {...anchorProps} className={getClassNames()} href={href}>{children}</a>;
+    }
+    if (isCustomAnchor()) {
+      return (
+        <AnchorComponent {...anchorProps} className={getClassNames()}>{children}</AnchorComponent>
+      );
+    }
+    return <li className={getClassNames()}>{children}</li>;
+  }
+}
 
 ListItem.propTypes = {
   activated: PropTypes.bool,

--- a/src/list-item.test.jsx
+++ b/src/list-item.test.jsx
@@ -1,7 +1,7 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import ListItem, { getClassNames } from './list-item';
+import ListItem from './list-item';
 
 const ANCHOR_COMPONENT = () => <p />;
 const ANCHOR_PROP_KEY = 'ANCHOR_PROP_KEY';
@@ -11,7 +11,28 @@ const CHILDREN = 'CHILDREN';
 const CLASS_NAME = 'CLASS_NAME';
 const HREF = 'HREF';
 
-test('ListItem > Renders an anchor', () => {
+test('Renders the default classNames', () => {
+  const wrapper = shallow(<ListItem>{CHILDREN}</ListItem>, { disableLifecycleMethods: true });
+  const expected = 'mdc-list-item';
+
+  const actual = wrapper.props().className;
+
+  expect(actual).toBe(expected);
+});
+
+test('Renders additional classNames based on props', () => {
+  const wrapper = shallow(
+    <ListItem activated className={CLASS_NAME}>{CHILDREN}</ListItem>,
+    { disableLifecycleMethods: true },
+  );
+  const expected = `mdc-list-item mdc-list-item--activated ${CLASS_NAME}`;
+
+  const actual = wrapper.props().className;
+
+  expect(actual).toBe(expected);
+});
+
+test('Renders an anchor', () => {
   const wrapper = shallow(
     <ListItem href={HREF}>{CHILDREN}</ListItem>,
     { disableLifecycleMethods: true },
@@ -29,7 +50,7 @@ test('ListItem > Renders an anchor', () => {
   expect(actualThird).toBe(expectedThird);
 });
 
-test('ListItem > Passes anchorProps, classNames, href and children to an anchor', () => {
+test('Passes anchorProps, href and children to an anchor', () => {
   const wrapper = shallow(
     <ListItem
       anchorProps={ANCHOR_PROPS}
@@ -42,22 +63,19 @@ test('ListItem > Passes anchorProps, classNames, href and children to an anchor'
   );
   const anchorProps = wrapper.find('a').props();
   const expectedFirst = ANCHOR_PROP_VALUE;
-  const expectedSecond = getClassNames(false, CLASS_NAME);
-  const expectedThird = HREF;
-  const expectedFourth = CHILDREN;
+  const expectedSecond = HREF;
+  const expectedThird = CHILDREN;
 
   const actualFirst = anchorProps[ANCHOR_PROP_KEY];
-  const actualSecond = anchorProps.className;
-  const actualThird = anchorProps.href;
-  const actualFourth = anchorProps.children;
+  const actualSecond = anchorProps.href;
+  const actualThird = anchorProps.children;
 
   expect(actualFirst).toBe(expectedFirst);
   expect(actualSecond).toBe(expectedSecond);
   expect(actualThird).toBe(expectedThird);
-  expect(actualFourth).toBe(expectedFourth);
 });
 
-test('ListItem > Renders a custom anchor component', () => {
+test('Renders a custom anchor component', () => {
   const wrapper = shallow(<ListItem AnchorComponent={ANCHOR_COMPONENT}>{CHILDREN}</ListItem>);
   const expectedFirst = false;
   const expectedSecond = true;
@@ -72,7 +90,7 @@ test('ListItem > Renders a custom anchor component', () => {
   expect(actualThird).toBe(expectedThird);
 });
 
-test('ListItem > Passes anchorProps, classNames and children to a custom anchor component', () => {
+test('Passes anchorProps and children to a custom anchor component', () => {
   const wrapper = shallow(
     <ListItem
       AnchorComponent={ANCHOR_COMPONENT}
@@ -85,19 +103,16 @@ test('ListItem > Passes anchorProps, classNames and children to a custom anchor 
   );
   const anchorComponentProps = wrapper.find(ANCHOR_COMPONENT).props();
   const expectedFirst = ANCHOR_PROP_VALUE;
-  const expectedSecond = getClassNames(false, CLASS_NAME);
-  const expectedThird = CHILDREN;
+  const expectedSecond = CHILDREN;
 
   const actualFirst = anchorComponentProps[ANCHOR_PROP_KEY];
-  const actualSecond = anchorComponentProps.className;
-  const actualThird = anchorComponentProps.children;
+  const actualSecond = anchorComponentProps.children;
 
   expect(actualFirst).toBe(expectedFirst);
   expect(actualSecond).toBe(expectedSecond);
-  expect(actualThird).toBe(expectedThird);
 });
 
-test('ListItem > Renders a list item', () => {
+test('Renders a list item', () => {
   const wrapper = shallow(<ListItem>{CHILDREN}</ListItem>);
   const expectedFirst = false;
   const expectedSecond = false;
@@ -112,34 +127,15 @@ test('ListItem > Renders a list item', () => {
   expect(actualThird).toBe(expectedThird);
 });
 
-test('ListItem > Passes classNames and children to a list item', () => {
+test('Passes children to a list item', () => {
   const wrapper = shallow(
     <ListItem className={CLASS_NAME}>{CHILDREN}</ListItem>,
     { disableLifecycleMethods: true },
   );
   const listItemProps = wrapper.find('li').props();
-  const expectedFirst = getClassNames(false, CLASS_NAME);
-  const expectedSecond = CHILDREN;
+  const expected = CHILDREN;
 
-  const actualFirst = listItemProps.className;
-  const actualSecond = listItemProps.children;
-
-  expect(actualFirst).toBe(expectedFirst);
-  expect(actualSecond).toBe(expectedSecond);
-});
-
-test('ListItem > getClassNames > Renders the default classNames', () => {
-  const expected = 'mdc-list-item';
-
-  const actual = getClassNames();
-
-  expect(actual).toBe(expected);
-});
-
-test('ListItem > getClassNames > Renders additional classNames', () => {
-  const expected = `mdc-list-item mdc-list-item--activated ${CLASS_NAME}`;
-
-  const actual = getClassNames(true, CLASS_NAME);
+  const actual = listItemProps.children;
 
   expect(actual).toBe(expected);
 });

--- a/src/list.jsx
+++ b/src/list.jsx
@@ -4,54 +4,48 @@ import React from 'react';
 
 import '@material/list/mdc-list.scss';
 
-export const DISPLAY_NAV = 'nav';
-export const DISPLAY_LIST = 'list';
-
-const getClassNames = (className, hasDarkTheme, isAvatarList, isDenseList, isTwoLineList) =>
-  classnames({
-    'mdc-list': true,
-    'mdc-list--theme-dark': hasDarkTheme,
-    'mdc-list--avatar-list': isAvatarList,
-    'mdc-list--dense': isDenseList,
-    'mdc-list--two-line': isTwoLineList,
-    [className]: !!className,
-  });
-
-const isNavList = display => display === DISPLAY_NAV;
-
-const List = ({
-  children,
-  className,
-  display,
-  hasDarkTheme,
-  isAvatarList,
-  isDenseList,
-  isTwoLineList,
-}) => {
-  const classNames =
-    getClassNames(className, hasDarkTheme, isAvatarList, isDenseList, isTwoLineList);
-  return isNavList(display) ?
-    <nav className={classNames}>{children}</nav> :
-    <ul className={classNames}>{children}</ul>;
-};
+class List extends React.Component {
+  constructor(props) {
+    super(props);
+    this.getClassNames = this.getClassNames.bind(this);
+    this.isNavList = this.isNavList.bind(this);
+  }
+  getClassNames() {
+    const { avatar, className, dense, twoLines } = this.props;
+    return classnames({
+      'mdc-list': true,
+      'mdc-list--avatar-list': avatar,
+      'mdc-list--dense': dense,
+      'mdc-list--two-line': twoLines,
+      [className]: !!className,
+    });
+  }
+  isNavList() {
+    return this.props.display === 'nav';
+  }
+  render() {
+    const { getClassNames, isNavList, props: { children } } = this;
+    return isNavList() ?
+      <nav className={getClassNames()}>{children}</nav> :
+      <ul className={getClassNames()}>{children}</ul>;
+  }
+}
 
 List.propTypes = {
+  avatar: PropTypes.bool,
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
-  hasDarkTheme: PropTypes.bool,
-  isAvatarList: PropTypes.bool,
-  isDenseList: PropTypes.bool,
-  display: PropTypes.oneOf([DISPLAY_NAV, DISPLAY_LIST]),
-  isTwoLineList: PropTypes.bool,
+  dense: PropTypes.bool,
+  display: PropTypes.oneOf(['nav', 'list']),
+  twoLines: PropTypes.bool,
 };
 
 List.defaultProps = {
+  avatar: false,
   className: undefined,
-  hasDarkTheme: false,
-  isAvatarList: false,
-  isDenseList: false,
-  display: DISPLAY_LIST,
-  isTwoLineList: false,
+  dense: false,
+  display: 'list',
+  twoLines: false,
 };
 
 export default List;

--- a/src/list.test.jsx
+++ b/src/list.test.jsx
@@ -1,7 +1,7 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import List, { DISPLAY_NAV } from './list';
+import List from './list';
 
 const CHILDREN = 'CHILDREN';
 
@@ -17,19 +17,11 @@ test('List > Renders the default classNames', () => {
 test('List > Renders additional classNames', () => {
   const CLASS_NAME = 'CLASS_NAME';
   const wrapper = shallow(
-    <List
-      className={CLASS_NAME}
-      hasDarkTheme
-      isAvatarList
-      isDenseList
-      isTwoLineList
-    >
-      {CHILDREN}
-    </List>,
+    <List className={CLASS_NAME} avatar dense twoLines>{CHILDREN}</List>,
     { disableLifecycleMethods: true },
   );
-  const expected = 'mdc-list mdc-list--theme-dark mdc-list--avatar-list ' +
-    `mdc-list--dense mdc-list--two-line ${CLASS_NAME}`;
+  const expected =
+    `mdc-list mdc-list--avatar-list mdc-list--dense mdc-list--two-line ${CLASS_NAME}`;
 
   const actual = wrapper.props().className;
 
@@ -62,10 +54,7 @@ test('List > Passes the className and children to the list', () => {
 });
 
 test('List > Renders as a nav', () => {
-  const wrapper = shallow(
-    <List display={DISPLAY_NAV}>{CHILDREN}</List>,
-    { disableLifecycleMethods: true },
-  );
+  const wrapper = shallow(<List display="nav">{CHILDREN}</List>, { disableLifecycleMethods: true });
   const expectedFirst = false;
   const expectedSecond = true;
 
@@ -77,10 +66,7 @@ test('List > Renders as a nav', () => {
 });
 
 test('List > Passes the className and children to the list', () => {
-  const wrapper = shallow(
-    <List display={DISPLAY_NAV}>{CHILDREN}</List>,
-    { disableLifecycleMethods: true },
-  );
+  const wrapper = shallow(<List display="nav">{CHILDREN}</List>, { disableLifecycleMethods: true });
   const listProps = wrapper.props();
   const expectedFirst = CHILDREN;
   const expectedSecond = 'mdc-list';


### PR DESCRIPTION
Upgrade packages. Rename list props to remove has and is prefixes

BREAKING CHANGE: List props have been renamed to conform